### PR TITLE
Additional integration tests and bugfixes

### DIFF
--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransport.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransport.java
@@ -53,6 +53,10 @@ public class FtpTransport implements Transport {
             setWorkingDirectory(ftpClient, baseDir);
         }
 
+        // Initialize the system type, which is cached for the duration of an FTP Client instance
+        // Having this value cached will resolve some issues with aborted file transfers and directory listings
+        FtpUtil.performSilently(ftpClient, ftpClient::getSystemType);
+
         return new FtpTransportSession(ftpClient);
     }
 

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransport.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransport.java
@@ -49,7 +49,9 @@ public class FtpTransport implements Transport {
         FtpUtil.connect(ftpClient, serverName, Integer.parseInt(serverPort));
         FtpUtil.login(ftpClient, hints.get(TRANSPORT_USERNAME), hints.get(TRANSPORT_PASSWORD));
         setTransferMode(ftpClient, transferMode);
-        setWorkingDirectory(ftpClient, baseDir);
+        if (baseDir != null && baseDir.trim().length() > 0) {
+            setWorkingDirectory(ftpClient, baseDir);
+        }
 
         return new FtpTransportSession(ftpClient);
     }

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransport.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransport.java
@@ -22,11 +22,7 @@ import org.dataconservancy.nihms.transport.TransportSession;
 
 import java.util.Map;
 
-import static org.dataconservancy.nihms.transport.ftp.FtpUtil.login;
-import static org.dataconservancy.nihms.transport.ftp.FtpUtil.makeDirectories;
 import static org.dataconservancy.nihms.transport.ftp.FtpUtil.performSilently;
-import static org.dataconservancy.nihms.transport.ftp.FtpUtil.setDataType;
-import static org.dataconservancy.nihms.transport.ftp.FtpUtil.setPasv;
 import static org.dataconservancy.nihms.transport.ftp.FtpUtil.setTransferMode;
 import static org.dataconservancy.nihms.transport.ftp.FtpUtil.setWorkingDirectory;
 
@@ -50,19 +46,8 @@ public class FtpTransport implements Transport {
         String transferMode = hints.get(FtpTransportHints.TRANSFER_MODE);
         String baseDir = hints.get(FtpTransportHints.BASE_DIRECTORY);
 
-        if (InetAddresses.isInetAddress(serverName)) {
-            performSilently(ftpClient, () -> {
-                ftpClient.connect(InetAddresses.forString(serverName), Integer.parseInt(serverPort));
-                return true;
-            });
-        } else {
-            performSilently(ftpClient, () -> {
-                ftpClient.connect(serverName, Integer.parseInt(serverPort));
-                return true;
-            });
-        }
-
-        login(ftpClient, hints.get(TRANSPORT_USERNAME), hints.get(TRANSPORT_PASSWORD));
+        FtpUtil.connect(ftpClient, serverName, Integer.parseInt(serverPort));
+        FtpUtil.login(ftpClient, hints.get(TRANSPORT_USERNAME), hints.get(TRANSPORT_PASSWORD));
         setTransferMode(ftpClient, transferMode);
         setWorkingDirectory(ftpClient, baseDir);
 

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
@@ -136,7 +136,7 @@ public class FtpTransportSession implements TransportSession {
 
     @Override
     public void close() throws Exception {
-        if (!transfer.isDone()) {
+        if (transfer != null && !transfer.isDone()) {
             LOG.debug("Closing {}@{}, cancelling pending transfer...",
                     this.getClass().getSimpleName(), toHexString(identityHashCode(this)));
             transfer.cancel(true);

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
@@ -198,6 +198,14 @@ public class FtpTransportSession implements TransportSession {
         } catch (Exception e) {
             caughtException.set(e);
             success.set(false);
+
+            try {
+                // If the file transfer doesn't even start we need to abort the STOR command so that the server isn't
+                // expecting data from us
+                performSilently(ftpClient, () -> ftpClient.abort());
+            } catch (Exception innerE) {
+                // ignore
+            }
         } finally {
             if (directory != null) {
                 try {

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
@@ -91,7 +91,11 @@ public class FtpTransportSession implements TransportSession {
             try {
                 return storeFile(destinationResource, content);
             } finally {
-                content.close();
+                try {
+                    content.close();
+                } catch (IOException e) {
+                    // ignore
+                }
             }
         });
 

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
@@ -117,8 +117,18 @@ public class FtpTransportSession implements TransportSession {
                 }
             };
         } catch (ExecutionException e) {
-            throw new RuntimeException(format(
-                    ERR_TRANSFER, destinationResource, "<host>", "<port>", e.getMessage()), e);
+            LOG.info(format(ERR_TRANSFER, destinationResource, "<host>", "<port>", e.getMessage()), e);
+            return new TransportResponse() {
+                @Override
+                public boolean success() {
+                    return false;
+                }
+
+                @Override
+                public Throwable error() {
+                    return e;
+                }
+            };
         }
 
     }

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpTransportSession.java
@@ -89,11 +89,6 @@ public class FtpTransportSession implements TransportSession {
 
         this.transfer = new FutureTask<>(() -> {
             try {
-                // make any parent directories defensively- if they don't exist create them,
-                // if they do exist, don't create them
-                makeDirectories(ftpClient, destinationResource.substring(0, destinationResource.lastIndexOf(PATH_SEP)));
-                setPasv(ftpClient, true);
-                setDataType(ftpClient, binary.name());
                 return storeFile(destinationResource, content);
             } finally {
                 content.close();
@@ -180,8 +175,10 @@ public class FtpTransportSession implements TransportSession {
 
         try {
             if (directory != null) {
-                performSilently(ftpClient, ftpClient -> ftpClient.changeWorkingDirectory(directory));
+                FtpUtil.setWorkingDirectory(ftpClient, directory);
             }
+            setPasv(ftpClient, true);
+            setDataType(ftpClient, binary.name());
             performSilently(ftpClient, ftpClient -> ftpClient.storeFile(fileName, content));
             success.set(true);
         } catch (Exception e) {

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
@@ -16,13 +16,17 @@
 
 package org.dataconservancy.nihms.transport.ftp;
 
+import com.google.common.net.InetAddresses;
 import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPReply;
 import org.dataconservancy.nihms.util.function.ExceptionThrowingCommand;
-import org.dataconservancy.nihms.util.function.ExceptionThrowingVoidCommand;
 import org.dataconservancy.nihms.util.function.ExceptionThrowingFunction;
+import org.dataconservancy.nihms.util.function.ExceptionThrowingVoidCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -31,9 +35,25 @@ import static java.lang.String.format;
 
 class FtpUtil {
 
+    private static final String OVERVIEW_CONNECTION_ATTEMPT = "({}) Connecting to {}:{} ...";
+
+    private static final String CONNECTION_FAILED_WITH_EXCEPTION = "Connection *FAILED* to %s:%s; Exception was: %s";
+
+    private static final String CONNECTION_ATTEMPT = "({}) Attempting connection to {}:{} ...";
+
+    private static final String CONNECTION_ATTEMPT_FAILED = "({}) Connection *FAILED* to {}:{} (sleeping for {} ms) ...";
+
+    private static final String CONNECTION_ATTEMPT_FAILED_WITH_EXCEPTION = "({}) Connection *FAILED* to {}:{} (sleeping for {} ms); Exception was: {}";
+
+    private static final String ERR_CONNECT = "({}) Error connecting to {}:{}; error code from the FTP server was '{}', and the error string was '{}'";
+
+    private static final String NOOP_FAILED = "({}) NOOP *FAILED*, connection to {}:{} not established.";
+
     private static final String ERR_REPLY = "Reply from the FTP server was '%s' (code: '%s')";
 
     private static final String ERR_CMD = "Exception performing FTP command; error message: %s";
+
+    private static final Logger LOG = LoggerFactory.getLogger(FtpUtil.class);
 
     /**
      * Character used to separate path components: e.g. use of the forward slash in the path '/path/to/file.txt'
@@ -50,13 +70,13 @@ class FtpUtil {
 
     static final Consumer<FTPClient> ASSERT_POSITIVE_COMPLETION = (ftpClient) -> {
         if (!ACCEPT_POSITIVE_COMPLETION.apply(ftpClient)) {
-            throw new RuntimeException(String.format(ERR_REPLY, ftpClient.getReplyString(), ftpClient.getReplyCode()));
+            throw new RuntimeException(format(ERR_REPLY, ftpClient.getReplyString(), ftpClient.getReplyCode()));
         }
     };
 
     static final Consumer<FTPClient> ASSERT_MKD_COMPLETION = (ftpClient) -> {
         if (!ACCEPT_MKD_COMPLETION.apply(ftpClient)) {
-            throw new RuntimeException(String.format(ERR_REPLY, ftpClient.getReplyString(), ftpClient.getReplyCode()));
+            throw new RuntimeException(format(ERR_REPLY, ftpClient.getReplyString(), ftpClient.getReplyCode()));
         }
     };
 
@@ -206,6 +226,120 @@ class FtpUtil {
     static Function<Integer, Boolean> acceptResponseCodes(Integer... responseCodes) {
         return (candidateResponseCode) -> Stream.of(responseCodes)
                 .anyMatch((code) -> code.equals(candidateResponseCode));
+    }
+
+    /**
+     * It seems there may be some issue with the Apache FTP library re-using closed sockets when
+     * establishing new connections.  Through trial and error it seems important to {@link FTPClient#connect(String, int) connect}, and then issue a {@link FTPClient#noop() NOOP} <em>before</em> attempting a login.  This method issues a {@code NOOP} in order to validate that the socket is actually connected.
+     * <p>
+     * When a connection fails, it is assumed to be a transient failure (again, due to potential bugs in the underlying
+     * Apache FTP library).  So this method will block and retry a failed connection up to a 30 second timeout before
+     * giving up.
+     * </p>
+     * @param ftpClient the FTP client instance that is not yet connected
+     * @param ftpHost the host to connect to (may be an IPv4, IPv6, or string domain name)
+     * @param ftpPort the port to connect to
+     */
+    static void connect(FTPClient ftpClient, String ftpHost, int ftpPort) {
+        LOG.debug(OVERVIEW_CONNECTION_ATTEMPT, ftpClientAsString(ftpClient), ftpHost, ftpPort);
+
+        long waitMs = 2000;
+        long start = System.currentTimeMillis();
+        boolean connectionSuccess = false;
+        Exception caughtException = null;
+
+        do {
+            try {
+                LOG.debug(CONNECTION_ATTEMPT, ftpClientAsString(ftpClient), ftpHost, ftpPort);
+                if (InetAddresses.isInetAddress(ftpHost)) {
+                    ftpClient.connect(InetAddresses.forString(ftpHost), ftpPort);
+                } else {
+                    ftpClient.connect(ftpHost, ftpPort);
+                }
+
+                int replyCode = ftpClient.getReplyCode();
+                String replyString = ftpClient.getReplyString();
+
+                if (!FTPReply.isPositiveCompletion(replyCode)) {
+                    LOG.debug(ERR_CONNECT, ftpClientAsString(ftpClient), ftpHost, ftpPort, replyCode, replyString);
+                } else {
+                    if (!ftpClient.sendNoOp()) {
+                        LOG.debug(NOOP_FAILED, ftpClientAsString(ftpClient), ftpHost, ftpPort);
+                    } else {
+                        connectionSuccess = true;
+                    }
+                }
+            } catch (Exception e) {
+                caughtException = e;
+                // Commonly catch FTPConnectionClosedException here
+                // is there a bug in the Apache FTP library which attempts to re-use a socket that has been closed?
+                // retry until a timeout is reached or a connection is successful.
+                try {
+                    LOG.debug(CONNECTION_ATTEMPT_FAILED_WITH_EXCEPTION,
+                            ftpClientAsString(ftpClient), ftpHost, ftpPort, waitMs, e.getMessage(), e);
+                    Thread.sleep(waitMs);
+                } catch (InterruptedException ie) {
+                    throw new RuntimeException(ie);
+                }
+            }
+        } while (!connectionSuccess && System.currentTimeMillis() - start < 30000);
+
+        if (!connectionSuccess) {
+            if (caughtException != null) {
+                throw new RuntimeException(format(CONNECTION_FAILED_WITH_EXCEPTION,
+                        ftpHost, ftpPort, caughtException.getMessage()), caughtException);
+            } else {
+                throw new RuntimeException(format(CONNECTION_FAILED_WITH_EXCEPTION, ftpHost, ftpPort, "null"));
+            }
+        }
+
+        LOG.debug("({}) Successfully connected to {}:{}", ftpClientAsString(ftpClient), ftpHost, ftpPort);
+    }
+
+    /**
+     * Logs out and disconnects from the supplied FTP client, as long as {@code ftpClient.isConnected()} returns true.
+     * <p>
+     * This method simply invokes {@link #disconnect(FTPClient, boolean)} with {@code force} equal to {@code false}.
+     * </p>
+     *
+     * @param ftpClient the FTP client to conditionally disconnect from
+     * @throws IOException
+     */
+    static void disconnect(FTPClient ftpClient) throws IOException {
+        disconnect(ftpClient, false);
+    }
+
+    /**
+     * Conditionally log out and disconnect from the supplied FTP client.  If {@code force} is {@code false}, this
+     * method first checks to see if the client is {@link FTPClient#isConnected() is connected} before attempting to
+     * disconnect.  If {@code force} is {@code true}, the {@link FTPClient#isConnected() connection status} is
+     * <em>not</em> considered prior to invoking {@link FTPClient#disconnect()}.
+     *
+     * @param ftpClient
+     * @param force
+     * @throws IOException
+     */
+    static void disconnect(FTPClient ftpClient, boolean force) throws IOException {
+        if (ftpClient == null) {
+            LOG.debug("({}) Not disconnecting because FTP client is null.", ftpClientAsString(ftpClient));
+            return;
+        }
+
+        if (!force && !ftpClient.isConnected()) {
+            LOG.debug("({}) Not disconnecting because the FTP client isn't connected.", ftpClientAsString(ftpClient));
+            return;
+        }
+
+        ftpClient.logout();
+        ftpClient.disconnect();
+    }
+
+    private static String ftpClientAsString(FTPClient ftpClient) {
+        if (ftpClient == null) {
+            return "null";
+        } else {
+            return ftpClient.getClass().getSimpleName() + "@" + Integer.toHexString(System.identityHashCode(ftpClient));
+        }
     }
 
 }

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
@@ -196,6 +196,9 @@ class FtpUtil {
     }
 
     static void setWorkingDirectory(FTPClient ftpClient, String directoryPath) {
+        if (directoryPath == null || directoryPath.trim().length() == 0) {
+            return;
+        }
         makeDirectories(ftpClient, directoryPath);
         performSilently(ftpClient, () -> ftpClient.changeWorkingDirectory(directoryPath));
     }

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
@@ -261,6 +261,9 @@ class FtpUtil {
         try {
             for (int i = 0; i < parts.length; i++) {
                 String part = parts[i];
+                if ("".equals(part)) {
+                    continue;
+                }
                 LOG.trace("Creating intermediate directory '{}'", part);
                 performSilently(ftpClient, () -> ftpClient.makeDirectory(part), ASSERT_MKD_COMPLETION);
                 LOG.trace("Changing to directory '{}'", part);

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
@@ -246,12 +246,14 @@ class FtpUtil {
     static void connect(FTPClient ftpClient, String ftpHost, int ftpPort) {
         LOG.debug(OVERVIEW_CONNECTION_ATTEMPT, ftpClientAsString(ftpClient), ftpHost, ftpPort);
 
-        long waitMs = 2000;
+        long initialWaitMs = 2000;
+        double backoffFactor = 1.5;
         long start = System.currentTimeMillis();
         boolean connectionSuccess = false;
         Exception caughtException = null;
 
         do {
+            long waitMs = initialWaitMs;
             try {
                 LOG.debug(CONNECTION_ATTEMPT, ftpClientAsString(ftpClient), ftpHost, ftpPort);
                 if (InetAddresses.isInetAddress(ftpHost)) {
@@ -281,6 +283,7 @@ class FtpUtil {
                     LOG.debug(CONNECTION_ATTEMPT_FAILED_WITH_EXCEPTION,
                             ftpClientAsString(ftpClient), ftpHost, ftpPort, waitMs, e.getMessage(), e);
                     Thread.sleep(waitMs);
+                    waitMs = Math.round(waitMs * backoffFactor);
                 } catch (InterruptedException ie) {
                     throw new RuntimeException(ie);
                 }

--- a/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
+++ b/nihms-ftp-transport/src/main/java/org/dataconservancy/nihms/transport/ftp/FtpUtil.java
@@ -246,14 +246,13 @@ class FtpUtil {
     static void connect(FTPClient ftpClient, String ftpHost, int ftpPort) {
         LOG.debug(OVERVIEW_CONNECTION_ATTEMPT, ftpClientAsString(ftpClient), ftpHost, ftpPort);
 
-        long initialWaitMs = 2000;
+        long waitMs = 2000;
         double backoffFactor = 1.5;
         long start = System.currentTimeMillis();
         boolean connectionSuccess = false;
         Exception caughtException = null;
 
         do {
-            long waitMs = initialWaitMs;
             try {
                 LOG.debug(CONNECTION_ATTEMPT, ftpClientAsString(ftpClient), ftpHost, ftpPort);
                 if (InetAddresses.isInetAddress(ftpHost)) {

--- a/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpTransportTest.java
+++ b/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpTransportTest.java
@@ -45,7 +45,6 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilTest.java
+++ b/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilTest.java
@@ -21,6 +21,7 @@ import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPReply;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 
 import java.io.IOException;
 
@@ -34,11 +35,14 @@ import static org.dataconservancy.nihms.transport.ftp.FtpUtil.PATH_SEP;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class FtpUtilTest {
@@ -336,6 +340,38 @@ public class FtpUtilTest {
         verify(ftpClient).makeDirectory(eq("subdir"));
         verify(ftpClient).changeWorkingDirectory(eq("subdir"));
         verify(ftpClient).changeWorkingDirectory(FTP_ROOT_DIR);
+    }
+
+    /**
+     * Insure that when FtpUtil.makeDirectories(ftpClient, "/dir/subdir") is invoked that:
+     * - the current working directory is obtained
+     * - the specified directory is created and reply code checked
+     * - the client changes the current working directory to the newly created directory (in prep for creating the sub
+     * directory)
+     * - the subdirectory is created, reply code checked, and changed into
+     * - changes the current working directory to the originally obtained working directory
+     *
+     * Specifically that leading slashes in the directory name are handled properly when parsed
+     * @throws IOException
+     */
+    @Test
+    public void testMakeNestedDirectoryStartingWithPathSep() throws IOException {
+        when(ftpClient.printWorkingDirectory()).thenReturn(FTP_ROOT_DIR);
+        when(ftpClient.makeDirectory(argThat(s -> s.length() > 0))).thenReturn(true);
+        when(ftpClient.getReplyCode())
+                .thenReturn(FTPReply.PATHNAME_CREATED)
+                .thenReturn(FTPReply.COMMAND_OK);
+        when(ftpClient.changeWorkingDirectory(anyString())).thenReturn(true);
+
+        FtpUtil.makeDirectories(ftpClient, PATH_SEP + "dir" + PATH_SEP + "subdir");
+
+        verify(ftpClient).makeDirectory(eq("dir"));
+        verify(ftpClient).changeWorkingDirectory(eq("dir"));
+        verify(ftpClient).makeDirectory(eq("subdir"));
+        verify(ftpClient).changeWorkingDirectory(eq("subdir"));
+        verify(ftpClient).changeWorkingDirectory(FTP_ROOT_DIR);
+        verify(ftpClient, never()).makeDirectory(eq(""));
+        verify(ftpClient, never()).makeDirectory(eq(PATH_SEP));
     }
 
     /**

--- a/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilTest.java
+++ b/nihms-ftp-transport/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/nihms-integration/pom.xml
+++ b/nihms-integration/pom.xml
@@ -61,6 +61,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/integration/BaseIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/integration/BaseIT.java
@@ -30,6 +30,10 @@ public abstract class BaseIT {
 
     protected static final String DOCKER_HOST_PROPERTY = "docker.host.address";
 
+    protected static final String FTP_INTEGRATION_USERNAME = "nihmsftpuser";
+
+    protected static final String FTP_INTEGRATION_PASSWORD = "nihmsftppass";
+
     protected String ftpHost;
 
     protected int ftpPort = 21;

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/integration/IntegrationUtil.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/integration/IntegrationUtil.java
@@ -109,6 +109,11 @@ public class IntegrationUtil {
         assertPositiveReply();
     }
 
+    public void logout() throws IOException {
+        assertTrue(ftpClient.logout());
+        assertPositiveReply();
+    }
+
     private String ftpClient() {
         if (ftpClient == null) {
             return "null";

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpTransportIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpTransportIT.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.nihms.transport.ftp;
+
+import org.apache.commons.io.input.BrokenInputStream;
+import org.apache.commons.net.ftp.FTPClient;
+import org.dataconservancy.nihms.integration.BaseIT;
+import org.dataconservancy.nihms.transport.Transport;
+import org.dataconservancy.nihms.transport.TransportResponse;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.stream.Stream;
+
+import static org.dataconservancy.nihms.transport.ftp.FtpUtil.PATH_SEP;
+import static org.dataconservancy.nihms.transport.ftp.FtpUtil.performSilently;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+public class FtpTransportIT extends BaseIT {
+
+    private static final String FILE_LISTING = "Listing files in directory {}: {}";
+
+    private FtpTransport transport;
+
+    private FtpTransportSession transportSession;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        transport = new FtpTransport(mock(FtpClientFactory.class));
+        transportSession = transport.open(ftpClient, new HashMap<String, String>() {
+            {
+                put(Transport.TRANSPORT_PROTOCOL, Transport.PROTOCOL.ftp.name());
+                put(Transport.TRANSPORT_AUTHMODE, Transport.AUTHMODE.userpass.name());
+                put(Transport.TRANSPORT_SERVER_FQDN, ftpHost);
+                put(Transport.TRANSPORT_SERVER_PORT, String.valueOf(ftpPort));
+                put(Transport.TRANSPORT_USERNAME, FTP_INTEGRATION_USERNAME);
+                put(Transport.TRANSPORT_PASSWORD, FTP_INTEGRATION_PASSWORD);
+                put(FtpTransportHints.TRANSFER_MODE, FtpTransportHints.MODE.stream.name());
+
+                // Opening a session puts us into this base directory, creating it if necessary.
+                put(FtpTransportHints.BASE_DIRECTORY, FtpTransportIT.class.getSimpleName());
+            }
+        });
+
+        // Assert we were put into the correct base directory.
+        assertEquals(asDirectory(FtpTransportIT.class.getSimpleName()), ftpClient.printWorkingDirectory());
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        if (transportSession != null) {
+            transportSession.close();
+        } else {
+            FtpUtil.disconnect(ftpClient, true);
+        }
+    }
+
+    @Test
+    public void testStoreFile() throws Exception {
+        String expectedFilename = "FtpTransportIT-testStoreFile.jpg";
+        TransportResponse response = transportSession.storeFile(expectedFilename, this.getClass().getResourceAsStream("/org.jpg"));
+
+        assertSuccessfulResponse(response);
+
+        assertFileListingContains(expectedFilename);
+    }
+
+    @Test
+    public void testStoreFileWithDirectory() throws Exception {
+        String expectedDirectory = "FtpTransportIT";
+        String expectedFilename = "testStoreFileWithDirectory.jpg";
+        String storeFilename = expectedDirectory + "/" + expectedFilename;
+        TransportResponse response = transportSession.storeFile(storeFilename, this.getClass().getResourceAsStream("/org.jpg"));
+
+        assertSuccessfulResponse(response);
+
+        assertFileListingContains(expectedDirectory);
+
+        FtpUtil.setWorkingDirectory(ftpClient, expectedDirectory);
+
+        assertFileListingContains(expectedFilename);
+    }
+
+    @Test
+    public void testStoreFileWithSameName() throws Exception {
+        String expectedFilename = "FtpTransportIT-testStoreFileWithSameName.jpg";
+        TransportResponse response = transportSession.storeFile(expectedFilename, this.getClass().getResourceAsStream("/org.jpg"));
+
+        assertSuccessfulResponse(response);
+
+        assertFileListingContains(expectedFilename);
+
+        response = transportSession.storeFile(expectedFilename, this.getClass().getResourceAsStream("/org.jpg"));
+
+        assertSuccessfulResponse(response);
+
+        assertFileListingContains(expectedFilename);
+    }
+
+    @Test
+    public void testSendFile() throws Exception {
+        String expectedFilename = "FtpTransportIT-testSendFile.jpg";
+        TransportResponse response = transportSession.send(expectedFilename, this.getClass().getResourceAsStream("/org.jpg"));
+
+        assertSuccessfulResponse(response);
+
+        assertFileListingContains(expectedFilename);
+    }
+
+    @Test
+    public void testSendFileWithException() throws Exception {
+        String expectedFilename = "FtpTransportIT-testSendFileWithException.jpg";
+        IOException expectedException = new IOException("Broken stream.");
+
+        TransportResponse response = transportSession.send(expectedFilename, new BrokenInputStream(expectedException));
+
+        assertErrorResponse(response);
+        assertEquals(expectedException, response.error().getCause().getCause().getCause());
+
+        performSilently(() -> assertTrue(Stream.of(ftpClient.listFiles())
+                .peek(f -> LOG.trace(FILE_LISTING, performSilently(() -> ftpClient.printWorkingDirectory()), f.getName()))
+                .noneMatch(candidateFile -> candidateFile.getName().endsWith(expectedFilename))));
+    }
+
+    @Test
+    public void testSendMultipleFiles() throws Exception {
+        String expectedFilename_01 = "FtpTransportIT-testSendMultipleFiles-01.jpg";
+        String expectedFilename_02 = "FtpTransportIT-testSendMultipleFiles-02.jpg";
+
+
+        TransportResponse response = transportSession.send(expectedFilename_01,
+                this.getClass().getResourceAsStream("/org.jpg"));
+
+        assertSuccessfulResponse(response);
+        assertFileListingContains(expectedFilename_01);
+
+        response = transportSession.send(expectedFilename_02,
+                this.getClass().getResourceAsStream("/org.jpg"));
+
+        assertSuccessfulResponse(response);
+        assertFileListingContains(expectedFilename_02);
+    }
+
+    /**
+     * Asserts that the supplied {@code response} represents a non-successful transaction occurred.
+     *
+     * @param response the transport response
+     */
+    private static void assertErrorResponse(TransportResponse response) {
+        assertNotNull(response);
+        assertFalse(response.success());
+        assertNotNull(response.error());
+    }
+
+    /**
+     * Asserts that the supplied {@code response} represents a successful transaction occurred.
+     *
+     * @param response the transport response
+     */
+    private static void assertSuccessfulResponse(TransportResponse response) {
+        assertNotNull(response);
+        assertTrue(response.success());
+        assertNull(response.error());
+    }
+
+    /**
+     * Lists the files in the current working directory of the FTP server, and asserts that there is at least one file
+     * name that matches the {@code expectedFilename}.
+     *
+     * @param expectedFilename the file that is expected to exist in the current working directory
+     */
+    private void assertFileListingContains(String expectedFilename) {
+        performSilently(() -> assertTrue(Stream.of(ftpClient.listFiles())
+                .peek(f -> LOG.trace(FILE_LISTING, performSilently(() -> ftpClient.printWorkingDirectory()), f.getName()))
+                .anyMatch(candidateFile -> candidateFile.getName().endsWith(expectedFilename))));
+    }
+
+    /**
+     * Prefixs the supplied path component with a path separator.  If the path component already starts with a path
+     * separator, it is returned unchanged
+     *
+     * @param pathComponent a non-null path component
+     * @return the path component prefixed with a path separator
+     */
+    private static String asDirectory(String pathComponent) {
+        if (pathComponent.startsWith(PATH_SEP)) {
+            return pathComponent;
+        }
+        return PATH_SEP + pathComponent;
+    }
+}

--- a/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilIT.java
+++ b/nihms-integration/src/test/java/org/dataconservancy/nihms/transport/ftp/FtpUtilIT.java
@@ -17,6 +17,7 @@
 package org.dataconservancy.nihms.transport.ftp;
 
 import org.dataconservancy.nihms.integration.BaseIT;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,11 +29,18 @@ import static org.junit.Assert.fail;
 
 public class FtpUtilIT extends BaseIT {
 
+    @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        itUtil.connect();
-        itUtil.login();
+        FtpUtil.connect(ftpClient, ftpHost, ftpPort);
+        FtpUtil.login(ftpClient, FTP_INTEGRATION_USERNAME, FTP_INTEGRATION_PASSWORD);
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        FtpUtil.disconnect(ftpClient);
     }
 
     @Test

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
@@ -35,6 +35,16 @@ public class NihmsAssembler implements Assembler {
 
     private static final String ERR_MAPPING_LOCATION = "Unable to resolve the location of a submitted file ('%s') to a Spring Resource type.";
 
+    private static final String FILE_PREFIX = "file:";
+
+    private static final String CLASSPATH_PREFIX = "classpath:";
+
+    private static final String WILDCARD_CLASSPATH_PREFIX = "classpath*:";
+
+    private static final String HTTP_PREFIX = "http:";
+
+    private static final String HTTPS_PREFIX = "https:";
+
     /**
      * Assembles Java {@code Object} references to <em>{@code InputStream}s</em> for each file in the package.  The
      * references are supplied to the {@code NihmsPackageStream} implementation, which does the heavy lifting of
@@ -57,18 +67,26 @@ public class NihmsAssembler implements Assembler {
                 .stream()
                 .map(NihmsFile::getLocation)
                 .map(location -> {
-                            if (location.startsWith("file:")) {
+                            if (location.startsWith(FILE_PREFIX)) {
                                 return new FileSystemResource(location);
                             }
-                            if (location.startsWith("classpath:")) {
-                                return new ClassPathResource(location);
+                            if (location.startsWith(CLASSPATH_PREFIX) ||
+                                    location.startsWith(WILDCARD_CLASSPATH_PREFIX)) {
+                                if (location.startsWith(WILDCARD_CLASSPATH_PREFIX)) {
+                                    return new ClassPathResource(location.substring(WILDCARD_CLASSPATH_PREFIX.length()));
+                                }
+                                return new ClassPathResource(location.substring(CLASSPATH_PREFIX.length()));
                             }
-                            if (location.startsWith("http")) {
+                            if (location.startsWith(HTTP_PREFIX) || location.startsWith(HTTPS_PREFIX)) {
                                 try {
                                     return new UrlResource(location);
                                 } catch (MalformedURLException e) {
                                     throw new RuntimeException(e.getMessage(), e);
                                 }
+                            }
+                            if (location.contains("/") || location.contains("\\")) {
+                                // assume it is a file
+                                return new FileSystemResource(location);
                             }
 
                             throw new RuntimeException(String.format(ERR_MAPPING_LOCATION, location));

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
@@ -16,6 +16,7 @@
 
 package org.dataconservancy.nihms.assembler.nihmsnative;
 
+import org.apache.commons.io.IOUtils;
 import org.dataconservancy.nihms.assembler.Assembler;
 import org.dataconservancy.nihms.assembler.PackageStream;
 import org.dataconservancy.nihms.model.NihmsFile;
@@ -25,6 +26,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 
+import java.io.ByteArrayInputStream;
 import java.net.MalformedURLException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,10 +47,10 @@ public class NihmsAssembler implements Assembler {
     public PackageStream assemble(NihmsSubmission submission) {
 
         // Prepare manifest and a serialization of the manifest
-        StreamingSerializer manifestSerializer = null; // new NihmsManifestSerializer(...)
+        StreamingSerializer manifestSerializer = () -> IOUtils.toInputStream("This is a manifest", "UTF-8");
 
         // Prepare metadata and a serialization of the metadata
-        StreamingSerializer metadataSerializer = null; // new NihmsMetadataSerializer(...)
+        StreamingSerializer metadataSerializer = () -> IOUtils.toInputStream("This is metadata", "UTF-8");
 
         // Locate byte streams for uploaded manuscript and supplemental data
         List<Resource> fileResources = submission.getFiles()

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 public class NihmsAssembler implements Assembler {
 
-    private static final String ERR_MAPPING_LOCATION = "Unable to map location %s to a Spring Resource type.";
+    private static final String ERR_MAPPING_LOCATION = "Unable to resolve the location of a submitted file ('%s') to a Spring Resource type.";
 
     /**
      * Assembles Java {@code Object} references to <em>{@code InputStream}s</em> for each file in the package.  The

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsPackageStream.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsPackageStream.java
@@ -39,7 +39,7 @@ public class NihmsPackageStream implements PackageStream {
 
     static final String ERR_CREATING_ARCHIVE_STREAM = "Error creating a %s archive output stream: %s";
 
-    static final String ERR_PUT_RESOURCE = "Error putting resource %s into archive output stream: %s";
+    static final String ERR_PUT_RESOURCE = "Error putting resource '%s' into archive output stream: %s";
 
     private static final Logger LOG = LoggerFactory.getLogger(NihmsPackageStream.class);
 

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/StreamingSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/StreamingSerializer.java
@@ -16,10 +16,11 @@
 
 package org.dataconservancy.nihms.assembler.nihmsnative;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 interface StreamingSerializer {
 
-    InputStream serialize();
+    InputStream serialize() throws IOException;
 
 }

--- a/nihms-submission-engine/src/main/java/org/dataconservancy/nihms/submission/SubmissionEngine.java
+++ b/nihms-submission-engine/src/main/java/org/dataconservancy/nihms/submission/SubmissionEngine.java
@@ -134,7 +134,7 @@ public class SubmissionEngine {
             resourceName = stream.metadata().name();
             // this is using the piped input stream (returned from stream.open()).  does this have to occur in a
             // separate thread?
-            response = session.send(resourceName, getTransportHints(submission), stream.open());
+            response = session.send(resourceName, stream.open());
         } catch (Exception e) {
             throw new SubmissionFailure(format(SUBMISSION_ERROR, resourceName, e.getMessage()), e);
         }

--- a/nihms-submission-engine/src/test/java/org/dataconservancy/nihms/submission/SubmissionEngineTest.java
+++ b/nihms-submission-engine/src/test/java/org/dataconservancy/nihms/submission/SubmissionEngineTest.java
@@ -86,13 +86,13 @@ public class SubmissionEngineTest {
         when(packageStream.metadata()).thenReturn(md);
         when(md.name()).thenReturn(expectedPackageName);
         when(packageStream.open()).thenReturn(contentStream);
-        when(session.send(anyString(), anyMap(), any(InputStream.class))).thenReturn(response);
+        when(session.send(anyString(), any(InputStream.class))).thenReturn(response);
         when(response.success()).thenReturn(true);
 
         engine.submit(expectedFormDataUrl);
 
         verify(builder).build(eq(expectedFormDataUrl));
-        verify(session).send(eq(expectedPackageName), anyMap(), eq(contentStream));
+        verify(session).send(eq(expectedPackageName), eq(contentStream));
         verify(response).success();
     }
 


### PR DESCRIPTION
* Key bugfixes:
  - performing a `STAT` command when opening the `FtpTransportSession` works around an issue when recovering from failed file transfers.
  - send an `ABORT` command when a file transfer fails
  - properly handle the creation of directories on the FTP server when the directory paths begin with a forward slash
  - properly handle the inclusion of package resource that are referenced as classpath resources (`classpath:` or `classpath*:`)
* Includes refactoring logic into the `FtpTransportSession.storeFile(...)` method.
* Be a little more rational with exception handing.
* Additional logging.
* Results in discovery/filing of #13 
* Adds mock serializers (for now, supporting integration testing) 