### PR TITLE
Serializers - add manifest element to the submission in the Builder, hope this fixes travis test failure

### DIFF
--- a/nihms-filesystem-builder/src/main/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilder.java
+++ b/nihms-filesystem-builder/src/main/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilder.java
@@ -19,6 +19,7 @@ package org.dataconservancy.nihms.builder.fs;
 import org.dataconservancy.nihms.builder.InvalidModel;
 import org.dataconservancy.nihms.builder.SubmissionBuilder;
 import org.dataconservancy.nihms.model.NihmsFile;
+import org.dataconservancy.nihms.model.NihmsManifest;
 import org.dataconservancy.nihms.model.NihmsMetadata;
 import org.dataconservancy.nihms.model.NihmsSubmission;
 
@@ -56,6 +57,7 @@ public class FilesystemModelBuilder implements SubmissionBuilder {
         NihmsMetadata metadata = new NihmsMetadata();
         NihmsMetadata.Journal journal = new NihmsMetadata.Journal();
         NihmsMetadata.Manuscript manuscript = new NihmsMetadata.Manuscript();
+        NihmsManifest manifest = new NihmsManifest();
 
         //... including the person object and its list
         NihmsMetadata.Person person = new NihmsMetadata.Person();
@@ -152,6 +154,7 @@ public class FilesystemModelBuilder implements SubmissionBuilder {
             //now populate the submission
             files.add(file);
             submission.setFiles(files);
+            manifest.setFiles(files);
 
             persons.add(person);
             metadata.setPersons(persons);
@@ -160,6 +163,7 @@ public class FilesystemModelBuilder implements SubmissionBuilder {
             metadata.setManuscriptMetadata(manuscript);
 
             submission.setMetadata(metadata);
+            submission.setManifest(manifest);
 
         } catch (IOException ioe) {
             throw new InvalidModel(ioe.getMessage(), ioe);

--- a/nihms-filesystem-builder/src/main/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilder.java
+++ b/nihms-filesystem-builder/src/main/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilder.java
@@ -121,6 +121,8 @@ public class FilesystemModelBuilder implements SubmissionBuilder {
                     case NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_URL:
                         manuscript.setManuscriptUrl(new URL(value));
                         break;
+                    case NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_TITLE:
+                        manuscript.setTitle(value);
 
                     //person metadata
                     case NihmsBuilderPropertyNames.NIHMS_PERSON_AUTHOR:

--- a/nihms-filesystem-builder/src/main/java/org/dataconservancy/nihms/builder/fs/NihmsBuilderPropertyNames.java
+++ b/nihms-filesystem-builder/src/main/java/org/dataconservancy/nihms/builder/fs/NihmsBuilderPropertyNames.java
@@ -40,6 +40,7 @@ public class NihmsBuilderPropertyNames {
     public static final String NIHMS_MANUSCRIPT_ID = "nihms.manuscript.id";
     public static final String NIHMS_MANUSCRIPT_PUBMEDCENTRALID = "nihms.manuscript.pubmedcentralid";
     public static final String NIHMS_MANUSCRIPT_PUBMEDID = "nihms.manuscript.pubmedid";
+    public static final String NIHMS_MANUSCRIPT_TITLE = "nihms.manuscript.title";
 
     public static final String NIHMS_SUBMISSION_ID = "nihms.submission.id";
     public static final String NIHMS_SUBMISSION_NAME = "nihms.submission.name";

--- a/nihms-filesystem-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
+++ b/nihms-filesystem-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
@@ -102,4 +102,16 @@ public class FilesystemModelBuilderTest {
                 submission.getMetadata().getManuscriptMetadata().getTitle());
     }
 
+    @Test
+    public void testManifestFileValues(){
+        //File Elements
+        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_FILE_LABEL),
+                submission.getManifest().getFiles().get(0).getLabel());
+        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_FILE_LOCATION),
+                submission.getManifest().getFiles().get(0).getLocation());
+        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_FILE_NAME),
+                submission.getManifest().getFiles().get(0).getName());
+
+    }
+
 }

--- a/nihms-filesystem-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
+++ b/nihms-filesystem-builder/src/test/java/org/dataconservancy/nihms/builder/fs/FilesystemModelBuilderTest.java
@@ -16,6 +16,7 @@
 
 package org.dataconservancy.nihms.builder.fs;
 
+import org.dataconservancy.nihms.model.NihmsMetadata;
 import org.dataconservancy.nihms.model.NihmsSubmission;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -97,6 +98,8 @@ public class FilesystemModelBuilderTest {
                 submission.getMetadata().getManuscriptMetadata().getManuscriptUrl().toString());
         assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_DOI),
                 submission.getMetadata().getManuscriptMetadata().getDoi().toString());
+        assertEquals(expectedProperties.getProperty(NihmsBuilderPropertyNames.NIHMS_MANUSCRIPT_TITLE),
+                submission.getMetadata().getManuscriptMetadata().getTitle());
     }
 
 }

--- a/nihms-filesystem-builder/src/test/resources/FilesystemModelBuilderTest.properties
+++ b/nihms-filesystem-builder/src/test/resources/FilesystemModelBuilderTest.properties
@@ -35,6 +35,7 @@ nihms.manuscript.url = http://farm.com.Cows
 nihms.manuscript.id = cow1
 nihms.manuscript.pubmedcentralid = PMC0000001
 nihms.manuscript.pubmedid = 0000001
+nihms.manuscript.title = A Treatise On Clover
 
 nihms.submission.id = 1
 nihms.submission.name = TheFarmFantastic

--- a/nihms-model/src/main/java/org/dataconservancy/nihms/model/NihmsMetadata.java
+++ b/nihms-model/src/main/java/org/dataconservancy/nihms/model/NihmsMetadata.java
@@ -109,6 +109,12 @@ public class NihmsMetadata {
          */
         public int relativeEmbargoPeriodMonths;
 
+        public String title;
+
+        public String getTitle() { return title; }
+
+        public void setTitle(String title) { this.title = title; }
+
         public String getNihmsId() {
             return nihmsId;
         }

--- a/nihms-native-assembler/pom.xml
+++ b/nihms-native-assembler/pom.xml
@@ -69,6 +69,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.10</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/nihms-native-assembler/pom.xml
+++ b/nihms-native-assembler/pom.xml
@@ -71,7 +71,12 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.10</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsAssembler.java
@@ -57,11 +57,9 @@ public class NihmsAssembler implements Assembler {
     public PackageStream assemble(NihmsSubmission submission) {
 
         // Prepare manifest and a serialization of the manifest
-        StreamingSerializer manifestSerializer = () -> IOUtils.toInputStream("This is a manifest", "UTF-8");
-
+        StreamingSerializer manifestSerializer = new NihmsManifestSerializer(submission.getManifest());
         // Prepare metadata and a serialization of the metadata
-        StreamingSerializer metadataSerializer = () -> IOUtils.toInputStream("This is metadata", "UTF-8");
-
+        StreamingSerializer metadataSerializer = new NihmsMetadataSerializer(submission.getMetadata());
         // Locate byte streams for uploaded manuscript and supplemental data
         List<Resource> fileResources = submission.getFiles()
                 .stream()

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.nihms.assembler.nihmsnative;
+import org.dataconservancy.nihms.model.NihmsFile;
+import org.dataconservancy.nihms.model.NihmsManifest;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+
+/**
+ * This class is a serializer for NihmsManifest which produces output conforming with the
+ * NIHMS Bulk Submission Specifications for Publishers document. For each file in the manifest's file list,
+ * we have a line
+ *
+ * {file_type}<tab>{label}<tab>{file_name}
+ *
+ * where the file type is one of
+ *
+ * “bulksub_meta_xml”, “manuscript”, “supplement”, “figure”, or “table”
+ *
+ * @author Jim Martino (jrm@jhu.edu)
+ */
+
+public class NihmsManifestSerializer implements StreamingSerializer{
+
+    private NihmsManifest manifest;
+
+
+    NihmsManifestSerializer(NihmsManifest manifest){
+        this.manifest = manifest;
+    }
+
+    public InputStream serialize(){
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        PrintWriter writer = new PrintWriter(os);
+
+        for (NihmsFile file : manifest.getFiles() ){
+            writer.write(file.getType().toString());
+            writer.append("\t");
+            writer.write(file.getLabel());
+            writer.append("\t");
+            writer.write(file.getName());
+            writer.append("\n");
+        }
+        writer.close();
+
+        byte[] bytes = os.toByteArray();
+
+        try (InputStream is = new ByteArrayInputStream(bytes)) {
+            os.close();
+            return is;
+        } catch (IOException ioe) {
+            throw new RuntimeException("Could not create Input Stream, or close Output Stream", ioe);
+        }
+    }
+
+}

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializer.java
@@ -42,7 +42,6 @@ public class NihmsManifestSerializer implements StreamingSerializer{
 
     private NihmsManifest manifest;
 
-
     NihmsManifestSerializer(NihmsManifest manifest){
         this.manifest = manifest;
     }
@@ -54,7 +53,9 @@ public class NihmsManifestSerializer implements StreamingSerializer{
         for (NihmsFile file : manifest.getFiles() ){
             writer.write(file.getType().toString());
             writer.append("\t");
-            writer.write(file.getLabel());
+            if(file.getLabel() != null) {
+                writer.write(file.getLabel());
+            }
             writer.append("\t");
             writer.write(file.getName());
             writer.append("\n");

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
@@ -161,10 +161,15 @@ public class NihmsMetadataSerializer implements StreamingSerializer{
                                  UnmarshallingContext context) {
             return null;
         }
+    }
 
-        private String booleanConvert(boolean b){
-            return(b?"yes":"no");
-        }
+    /**
+     * Method to convert boolean into yes ore no
+     * @param  b the boolean to convert
+     * @return yes if true, no if false
+     */
+    String booleanConvert(boolean b){
+        return(b?"yes":"no");
     }
 
 }

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
@@ -32,7 +32,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-
+/**
+ * XML serialization of our NihmsMetadata to conform with the bulk submission dtd
+ *
+ * @author Jim Martino (jrm@jhu.edu)
+ */
 public class NihmsMetadataSerializer implements StreamingSerializer{
 
     private NihmsMetadata metadata;
@@ -164,7 +168,7 @@ public class NihmsMetadataSerializer implements StreamingSerializer{
     }
 
     /**
-     * Method to convert boolean into yes ore no
+     * Method to convert boolean into yes or no
      * @param  b the boolean to convert
      * @return yes if true, no if false
      */

--- a/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
+++ b/nihms-native-assembler/src/main/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializer.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.nihms.assembler.nihmsnative;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import com.thoughtworks.xstream.io.xml.DomDriver;
+import com.thoughtworks.xstream.io.xml.XmlFriendlyNameCoder;
+import org.dataconservancy.nihms.model.NihmsMetadata;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+
+public class NihmsMetadataSerializer implements StreamingSerializer{
+
+    private NihmsMetadata metadata;
+
+    NihmsMetadataSerializer(NihmsMetadata metadata){
+        this.metadata = metadata;
+    }
+
+    public InputStream serialize() {
+        XStream xstream = new XStream(new DomDriver("UTF-8", new XmlFriendlyNameCoder("_-", "_")));
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        xstream.registerConverter(new MetadataConverter());
+        xstream.alias("nihms-submit", NihmsMetadata.class);
+        xstream.toXML(metadata, os);
+
+        byte[] bytes = os.toByteArray();
+
+        try (InputStream is = new ByteArrayInputStream(bytes)) {
+            os.close();
+            return is;
+        } catch (IOException ioe) {
+            throw new RuntimeException("Could not create Input Stream, or close Output Stream", ioe);
+        }
+
+    }
+
+    private class MetadataConverter implements Converter {
+        public boolean canConvert(Class clazz) {
+            return NihmsMetadata.class == clazz;
+        }
+
+        public void marshal(Object value, HierarchicalStreamWriter writer,
+                            MarshallingContext context) {
+            NihmsMetadata metadata = (NihmsMetadata) value;
+
+            //process manuscript element (except, strangely, for title, which we do after journal)
+            NihmsMetadata.Manuscript manuscript = metadata.getManuscriptMetadata();
+            writer.startNode("manuscript");
+            if(manuscript.getNihmsId() != null) {
+                writer.addAttribute("id", manuscript.getNihmsId());
+            }
+
+            //primitive types
+            writer.addAttribute("publisher_pdf", booleanConvert(manuscript.isPublisherPdf()));
+            writer.addAttribute("show_publisher_pdf", booleanConvert(manuscript.isShowPublisherPdf()));
+            writer.addAttribute("embargo", String.valueOf(manuscript.getRelativeEmbargoPeriodMonths()));
+
+            if(manuscript.getPubmedId() != null){
+                writer.addAttribute("pmid", manuscript.getPubmedId());
+            }
+
+            if(manuscript.getPubmedCentralId() != null){
+                writer.addAttribute("pmcid", manuscript.getPubmedCentralId());
+            }
+            if(manuscript.getManuscriptUrl() != null){
+                writer.addAttribute("href", manuscript.getManuscriptUrl().toString());
+            }
+            if(manuscript.getDoi() != null){
+                writer.addAttribute("doi", manuscript.getDoi().toString());
+            }
+            writer.endNode(); //end manuscript
+
+            //process journal
+            NihmsMetadata.Journal journal = metadata.getJournalMetadata();
+            writer.startNode("journal-meta");
+            if (journal.getJournalId() != null) {
+                writer.startNode("journal-id");
+                if (journal.getJournalType() != null) {
+                    writer.addAttribute("journal-id-type", journal.getJournalType());
+                }
+                writer.setValue(journal.getJournalId());
+                writer.endNode();
+            }
+
+            if (journal.getIssn() != null) {
+                writer.startNode("issn");
+                if (journal.getPubType() != null) {
+                    writer.addAttribute("pub-type", journal.getPubType().toString());
+                }
+                writer.setValue(journal.getIssn());
+                writer.endNode();
+            }
+            if (journal.getJournalTitle() != null) {
+                writer.startNode("journal-title");
+                writer.setValue(journal.getJournalTitle());
+                writer.endNode();
+            }
+            writer.endNode(); //end journal-meta
+
+            //now process full manuscript title
+            if (manuscript.getTitle() != null) {
+                writer.startNode("title");
+                writer.setValue(manuscript.getTitle());
+                writer.endNode();
+            }
+
+            //process contacts
+            List<NihmsMetadata.Person> persons = metadata.getPersons();
+            if (persons.size()>0) {
+                writer.startNode("contacts");
+                for (NihmsMetadata.Person person : persons){
+                    writer.startNode("person");
+                    if (person.getFirstName() != null) {
+                        writer.addAttribute("fname",person.getFirstName());
+                    }
+                    if (person.getMiddleName() != null) {
+                        writer.addAttribute("mname",person.getMiddleName());
+                    }
+                    if (person.getLastName() != null) {
+                        writer.addAttribute("lname",person.getLastName());
+                    }
+                    if (person.getEmail() != null) {
+                        writer.addAttribute("email",person.getEmail());
+                    }
+                    //primitive types
+                    writer.addAttribute("pi", booleanConvert(person.isPi()));
+                    writer.addAttribute("corrpi", booleanConvert(person.isCorrespondingPi()));
+                    writer.addAttribute("author", booleanConvert(person.isAuthor()));
+                    writer.endNode(); // end person
+                }
+                writer.endNode(); //end contacts
+            }
+        }
+
+        public Object  unmarshal(HierarchicalStreamReader reader,
+                                 UnmarshallingContext context) {
+            return null;
+        }
+
+        private String booleanConvert(boolean b){
+            return(b?"yes":"no");
+        }
+    }
+
+}

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializerTest.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializerTest.java
@@ -29,6 +29,9 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * @author Jim Martino (jrm@jhu.edu)
+ */
 public class NihmsManifestSerializerTest {
 
     @Test
@@ -50,10 +53,16 @@ public class NihmsManifestSerializerTest {
         file3.setName("File Three name");
         file3.setType(NihmsFileType.table);
 
+        NihmsFile file4 = new NihmsFile();
+        //label not always required
+        file4.setName("File Four name");
+        file4.setType(NihmsFileType.manuscript);
+
         List<NihmsFile> files = new ArrayList<>();
         files.add(file1);
         files.add(file2);
         files.add(file3);
+        files.add(file4);
 
         manifest.setFiles(files);
 
@@ -61,10 +70,10 @@ public class NihmsManifestSerializerTest {
 
         InputStream is = underTest.serialize();
 
-        //tab delimited lines
-        String expected = "figure	File One Label	File One name" + "\n" +
-                "bulksub_meta_xml	File Two Label	File Two name" + "\n" +
-                "table	File Three Label	File Three name" + "\n";
+        String expected = "figure" + "\t" + "File One Label" + "\t" +"File One name" + "\n" +
+                "bulksub_meta_xml"+ "\t" + "File Two Label" + "\t" +"File Two name" + "\n" +
+                "table" + "\t" + "File Three Label" + "\t" + "File Three name" + "\n" +
+                "manuscript" + "\t\t" + "File Four name"+ "\n";
 
         String actual = "";
 

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializerTest.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsManifestSerializerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.nihms.assembler.nihmsnative;
+
+
+import org.apache.commons.io.IOUtils;
+import org.dataconservancy.nihms.model.NihmsFile;
+import org.dataconservancy.nihms.model.NihmsFileType;
+import org.dataconservancy.nihms.model.NihmsManifest;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NihmsManifestSerializerTest {
+
+    @Test
+    public void testManifestSerialization(){
+        NihmsManifest manifest = new NihmsManifest();
+
+        NihmsFile file1 = new NihmsFile();
+        file1.setLabel("File One Label");
+        file1.setName("File One name");
+        file1.setType(NihmsFileType.figure);
+
+        NihmsFile file2 = new NihmsFile();
+        file2.setLabel("File Two Label");
+        file2.setName("File Two name");
+        file2.setType(NihmsFileType.bulksub_meta_xml);
+
+        NihmsFile file3 = new NihmsFile();
+        file3.setLabel("File Three Label");
+        file3.setName("File Three name");
+        file3.setType(NihmsFileType.table);
+
+        List<NihmsFile> files = new ArrayList<>();
+        files.add(file1);
+        files.add(file2);
+        files.add(file3);
+
+        manifest.setFiles(files);
+
+        NihmsManifestSerializer underTest = new NihmsManifestSerializer(manifest);
+
+        InputStream is = underTest.serialize();
+
+        //tab delimited lines
+        String expected = "figure	File One Label	File One name" + "\n" +
+                "bulksub_meta_xml	File Two Label	File Two name" + "\n" +
+                "table	File Three Label	File Three name" + "\n";
+
+        String actual = "";
+
+        try {
+          actual = IOUtils.toString(is, "UTF-8");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        assertEquals(expected, actual);
+
+    }
+}

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializerTest.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializerTest.java
@@ -36,7 +36,7 @@ import java.util.List;
 import static org.junit.Assert.assertTrue;
 
 /**
- * This is a test for the metadat serializer. for now we just validate against the bulk submission dtd
+ * This is a test for the metadata serializer. for now we just validate against the bulk submission dtd
  *
  * @author Jim Martino (jrm@jhu.edu)
  */

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializerTest.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializerTest.java
@@ -135,7 +135,7 @@ public class NihmsMetadataSerializerTest {
         os.close();
 
         Validator v = Validator.forLanguage(Languages.XML_DTD_NS_URI);
-        StreamSource dtd = new StreamSource(getClass().getResourceAsStream("bulksubmissiom.dtd"));
+        StreamSource dtd = new StreamSource(getClass().getResourceAsStream("bulksubmission.dtd"));
         dtd.setSystemId(getClass().getResource("bulksubmission.dtd").toURI().toString());
         v.setSchemaSource(dtd);
         StreamSource s = new StreamSource("MetadataSerializerTest.xml");

--- a/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializerTest.java
+++ b/nihms-native-assembler/src/test/java/org/dataconservancy/nihms/assembler/nihmsnative/NihmsMetadataSerializerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.nihms.assembler.nihmsnative;
+
+import org.apache.commons.io.IOUtils;
+import org.dataconservancy.nihms.model.NihmsMetadata;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class NihmsMetadataSerializerTest {
+
+    @Test
+    public void metadataSerializerTest() throws MalformedURLException {
+
+        //set up metadata snd its fields;
+        NihmsMetadata metadata = new NihmsMetadata();
+
+        //NihmsMetadata.Article article = new NihmsMetadata.Article();
+        NihmsMetadata.Journal journal = new NihmsMetadata.Journal();
+        NihmsMetadata.Manuscript manuscript = new NihmsMetadata.Manuscript();
+        List<NihmsMetadata.Person> personList = new ArrayList<>();
+
+        //populate journal metadata
+        journal.setIssn("1234-5678");
+        journal.setJournalId("FJ001");
+        journal.setJournalTitle("Dairy Cow Monthly");
+        journal.setPubType(NihmsMetadata.JOURNAL_PUBLICATION_TYPE.epub);
+
+        //populate manuscript metadata
+        manuscript.setDoi(URI.create("doi:10.1234/smh0000001"));
+        manuscript.setManuscriptUrl(new URL("http://farm.com/Cows"));
+        manuscript.setNihmsId("00001");
+        manuscript.setPublisherPdf(true);
+        //manuscript.setPubmedCentralId("PMC00001");
+        manuscript.setPubmedId("00001");
+        manuscript.setRelativeEmbargoPeriodMonths(0);
+        manuscript.setShowPublisherPdf(false);
+        manuscript.setTitle("Manuscript Title");
+
+        //populate persons
+        NihmsMetadata.Person person1 = new NihmsMetadata.Person();
+        person1.setAuthor(true);
+        person1.setCorrespondingPi(false);
+        person1.setEmail("person@farm.com");
+        person1.setFirstName("Bessie");
+        person1.setLastName("Cow");
+        person1.setMiddleName("The");
+        person1.setPi(true);
+        personList.add(person1);
+
+        NihmsMetadata.Person person2 = new NihmsMetadata.Person();
+        person2.setAuthor(false);
+        person2.setCorrespondingPi(true);
+        person2.setEmail("person@farm.com");
+        person2.setFirstName("Elsie");
+        person2.setLastName("Cow");
+        person2.setMiddleName("The");
+        person2.setPi(false);
+        personList.add(person2);
+
+        NihmsMetadata.Person person3 = new NihmsMetadata.Person();
+        person3.setAuthor(false);
+        person3.setCorrespondingPi(false);
+        person3.setEmail("person@farm.com");
+        person3.setFirstName("Mark");
+        person3.setLastName("Cow");
+        person3.setMiddleName("The");
+        person3.setPi(false);
+        personList.add(person3);
+
+        NihmsMetadata.Person person4 = new NihmsMetadata.Person();
+        person4.setAuthor(false);
+        person4.setCorrespondingPi(false);
+        person4.setEmail("person@farm.com");
+        person4.setFirstName("John");
+        person4.setLastName("Cow");
+        person4.setMiddleName("The");
+        person4.setPi(true);
+        personList.add(person4);
+
+        metadata.setJournalMetadata(journal);
+        metadata.setManuscriptMetadata(manuscript);
+        metadata.setPersons(personList);
+
+
+        NihmsMetadataSerializer underTest = new NihmsMetadataSerializer(metadata);
+
+        InputStream is = underTest.serialize();
+
+        //System.out.println(IOUtils.toString(is, "UTF-8"));
+
+        try {
+            System.out.println(IOUtils.toString(is, "UTF-8"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        //assertEquals(expected, actual);
+
+    }
+
+
+
+}

--- a/nihms-native-assembler/src/test/resources/org/dataconservancy/nihms/assembler/nihmsnative/bulksubmission.dtd
+++ b/nihms-native-assembler/src/test/resources/org/dataconservancy/nihms/assembler/nihmsnative/bulksubmission.dtd
@@ -1,0 +1,128 @@
+<!ELEMENT nihms-submit (manuscript?, journal-meta, (article-meta | permissions)?, title, contacts, disclaimer?, custom-meta-group?) >
+<!ATTLIST nihms-submit
+        xmlns:xlink			CDATA		     #FIXED 'http://www.w3.org/1999/xlink'
+        agency				CDATA				#IMPLIED  >
+
+
+<!ELEMENT manuscript EMPTY>
+<!ATTLIST  manuscript
+        id CDATA #IMPLIED
+        publisher_pdf (yes|no) #IMPLIED
+        show_publisher_pdf (yes|no) #IMPLIED
+        embargo CDATA #IMPLIED
+        pmid CDATA #IMPLIED
+        pmcid CDATA #IMPLIED
+        href CDATA #IMPLIED
+        doi CDATA #IMPLIED
+
+        >
+<!-- embargo = count of months, 0 to 12 -->
+
+
+<!ELEMENT journal-meta ( (journal-id | issn), issn*, journal-title?) >
+
+<!ELEMENT journal-id (#PCDATA) >
+<!ATTLIST journal-id
+        journal-id-type (nlm-ta) #REQUIRED >
+<!ELEMENT journal-title (#PCDATA) >
+<!ELEMENT issn (#PCDATA) >
+<!ATTLIST issn
+        pub-type (ppub|epub) #REQUIRED >
+
+<!ELEMENT title (#PCDATA) >
+
+<!ELEMENT contacts (person+)>
+
+<!ELEMENT person (grant*)>
+<!ATTLIST person
+        fname CDATA #REQUIRED
+        mname CDATA #IMPLIED
+        lname CDATA #REQUIRED
+        email CDATA #IMPLIED
+        auth CDATA #IMPLIED
+        pi (yes|no) #IMPLIED
+        corrpi (yes|no) #IMPLIED
+        author (yes|no) #IMPLIED
+        agency	CDATA	#IMPLIED
+        center	CDATA	#IMPLIED
+        >
+
+<!ELEMENT grant EMPTY >
+<!ATTLIST grant
+        id CDATA #IMPLIED
+        authority (nih|wt|hhmi|era|nasa) #REQUIRED
+        project	CDATA		#IMPLIED
+        >
+
+<!ELEMENT article-meta (article-id*, subj-group*, pub-date+, volume, issue, (fpage | elocation-id), lpage?, copyright-statement?, license?, self-uri*) >
+
+<!ELEMENT permissions	(copyright-statement?, license?) >
+
+<!ELEMENT volume (#PCDATA) >
+
+<!ELEMENT issue (#PCDATA) >
+
+<!ELEMENT fpage (#PCDATA) >
+
+<!ELEMENT elocation-id (#PCDATA) >
+
+<!ELEMENT lpage (#PCDATA) >
+
+<!ELEMENT copyright-statement (#PCDATA) >
+
+<!ELEMENT article-id (#PCDATA) >
+<!ATTLIST article-id
+        pub-id-type		(doi|pmid|pmcid|publisher-id)		#REQUIRED >
+
+<!ELEMENT pub-date ( ((day?, month?) | season?), year) >
+<!ATTLIST pub-date
+        pub-type (ppub|epub|epub-ppub|epreprint|collection)	#REQUIRED >
+
+<!-- use ppub for print publication, epub for electronic or online publication date -->
+
+
+<!ELEMENT day (#PCDATA) >
+
+<!ELEMENT month (#PCDATA) >
+
+<!ELEMENT season (#PCDATA) >
+
+<!ELEMENT year (#PCDATA) >
+
+<!ELEMENT license (p) >
+<!ATTLIST license
+        license-type	CDATA		#IMPLIED
+        xlink:href				CDATA		#IMPLIED
+        >
+
+
+<!ELEMENT self-uri EMPTY>
+<!ATTLIST self-uri
+        xlink:href		CDATA		#REQUIRED
+        xmlns:xlink		CDATA		#IMPLIED
+        content-type	CDATA		#IMPLIED
+        >
+
+
+
+<!ELEMENT custom-meta-group  (custom-meta+)>
+
+<!ELEMENT custom-meta (#PCDATA) >
+<!ATTLIST custom-meta
+        name		CDATA		#REQUIRED>
+
+<!ELEMENT p	(#PCDATA|uri)* >
+
+<!ELEMENT uri (#PCDATA)>
+<!ATTLIST uri
+        xlink:href		CDATA		#IMPLIED
+        href				CDATA		#IMPLIED
+        >
+
+<!-- use subj-group and subject for TOC headings -->
+
+<!ELEMENT subj-group (subject, subj-group?) >
+
+<!ELEMENT subject (#PCDATA) >
+
+<!ELEMENT disclaimer (#PCDATA) >

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,8 @@
         <okhttp.version>3.9.0</okhttp.version>
         <guava.version>23.5-jre</guava.version>
         <args4j.version>2.33</args4j.version>
+        <xmlunit.version>2.3.0</xmlunit.version>
+        <xstream.version>1.4.10</xstream.version>
     </properties>
 
     <build>
@@ -231,6 +233,19 @@
                 <artifactId>args4j</artifactId>
                 <version>${args4j.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.thoughtworks.xstream</groupId>
+                <artifactId>xstream</artifactId>
+                <version>${xstream.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.xmlunit</groupId>
+                <artifactId>xmlunit-core</artifactId>
+                <version>${xmlunit.version}</version>
+            </dependency>
+
 
         </dependencies>
 


### PR DESCRIPTION
latest commit is to add a manifest object to the submission builder, populated with the file list